### PR TITLE
Fix duplicate search results: updateSearchResult is idempotent

### DIFF
--- a/src/app/card-search.tsx
+++ b/src/app/card-search.tsx
@@ -63,6 +63,7 @@ export const CardSearch: FC<CardSearchProps> = ({ initialQuery = '' }) => {
         setSearchResults((searchResults) => {
           const newPages = searchResults.slice(0);
           newPages[page] = cardData;
+          return newPages;
         });
       } else {
         setIsLastPage(true);

--- a/src/app/card-search.tsx
+++ b/src/app/card-search.tsx
@@ -22,7 +22,7 @@ interface CardSearchProps {
 }
 
 export const CardSearch: FC<CardSearchProps> = ({ initialQuery = '' }) => {
-  const [searchResults, setSearchResults] = useState<Card[]>([]);
+  const [searchResults, setSearchResults] = useState<Card[][]>([]);
   const [searchQuery, setSearchQuery] = useState<string>(initialQuery);
   const [pageNumber, setPageNumber] = useState<number>(1);
   const [isLastPage, setIsLastPage] = useState<boolean>(false);
@@ -60,7 +60,10 @@ export const CardSearch: FC<CardSearchProps> = ({ initialQuery = '' }) => {
     startTransition(async () => {
       const cardData = await getCards(query, page);
       if (cardData.length > 0) {
-        setSearchResults((searchResults) => [...searchResults, ...cardData]);
+        setSearchResults((searchResults) => {
+          const newPages = searchResults.slice(0);
+          newPages[page] = cardData;
+        });
       } else {
         setIsLastPage(true);
       }
@@ -80,7 +83,7 @@ export const CardSearch: FC<CardSearchProps> = ({ initialQuery = '' }) => {
         onChange={handleChange}
         onTypingComplete={handleTypingComplete}
       />
-      {searchResults.map((card) => (
+      {searchResults.flat().map((card) => (
         <CardResult key={uid(100)} card={card} />
       ))}
       {isPending && searchResults.length === 0 && <CardResultSkeleton />}


### PR DESCRIPTION
(Not tested)

Do not assume results are received in-order or duplicate free.

(The following were added in edit:)

**Bug Context:** During IRL testing someone occasionally got duplicate search results. We weren't able to nail down a consistent way to reproduce it. 

**Suspected Cause:** Matt wondered if the following `useEffect` was invoked multiple times for the same page number, as we saw such a duplicated request in the network inspector in IRL

```js
  useEffect(() => {
    if (searchQuery.length > 0) {
      updateSearchResults(searchQuery, pageNumber);
    }
  }, [searchQuery, pageNumber]);
``` 

Looking at the code, it seems that it assumed that `updateSearchResults()` will be invoked for a monotonically increasing `pageNumber` and at most once for each unique `searchQuery` and `pageNumber`, and also that by the time the await has finished, that the `searchQuery` is still representing the current search query.

**Fix:** Remove assumptions on how `updateSearchResults` are invoked, and save the results in a data structure indexed by page number so that duplicate results for the same page will not show up duplicated to the user. This changes the mental model of `updateSearchResults` from a state machine model to a knowledge accumulating model, which is hopefully easier to reason about.

**TODO:** Consider also rejecting results returned to use if the search query associated with the results no longer matches the current search query.

**Risk areas:** Search results and paging.

**Review:** TODO